### PR TITLE
fix(docs): correct spec download URLs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -235,7 +235,7 @@ const config = {
             outputDir: "docs/plex-tv", // Output directory for generated .mdx docs
             template: "api.mustache",
             downloadUrl:
-              "https://raw.githubusercontent.com/LukeHagar/plex-api-spec/main/plex-api-spec-dereferenced.yaml",
+              "https://raw.githubusercontent.com/LukeHagar/plex-api-spec/main/plex-tv-spec-dereferenced.yaml",
             sidebarOptions: {
               groupPathsBy: "tag",
               categoryLinkSource: "tag",
@@ -247,7 +247,7 @@ const config = {
             outputDir: "docs/plex", // Output directory for generated .mdx docs
             template: "api.mustache",
             downloadUrl:
-              "https://raw.githubusercontent.com/LukeHagar/plex-api-spec/main/plex-api-spec-dereferenced.yaml",
+              "https://raw.githubusercontent.com/LukeHagar/plex-api-spec/main/plex-media-server-spec-dereferenced.yaml",
             sidebarOptions: {
               groupPathsBy: "tag",
               categoryLinkSource: "tag",


### PR DESCRIPTION
This PR updates both export URLs which are returning 404.

Alternative to using specs from an external repo could be this: https://github.com/ReenigneArcher/plex-docs/commit/3d714cf8dc79ee8dd84d733557df62d7c34a6402